### PR TITLE
V0p1p11

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -9,3 +9,4 @@ jobs:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,4 +60,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
+          GKSwstype: "100" # https://discourse.julialang.org/t/generation-of-documentation-fails-qt-qpa-xcb-could-not-connect-to-display/60988
+
 

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+AirSeaFluxes = "3dfee02d-11ce-464a-9ee1-cf3f5c5ccad7"
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,8 +1,8 @@
 using Documenter, Literate, ClimateModels, Pkg
 
 pth=@__DIR__
-lst=("defaults.jl",)
-lstExecute=("defaults.jl",)
+lst=("defaults.jl","RandomWalker.jl","ShallowWaters.jl","MITgcm.jl","Speedy.jl","CMIP6.jl")
+lstExecute=("defaults.jl","RandomWalker.jl","ShallowWaters.jl","MITgcm.jl","CMIP6.jl")
 for i in lst
     EXAMPLE = joinpath(pth, "..", "examples", i)
     OUTPUT = joinpath(pth, "src","generated")

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -18,6 +18,11 @@ The next sections are examples which broadly fall into two categories.
 ```@contents
 Pages = [
     "generated/defaults.md",
+    "generated/RandomWalker.md",
+    "generated/ShallowWaters.md",
+    "generated/MITgcm.md",
+    "generated/Speedy.md",
+    "generated/CMIP6.md",
 ]
 Depth = 2
 ```

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -200,12 +200,7 @@ end
 Default for building/compiling model when it is a cloned julia package    
 """
 function build_the_pkg(x)
-    pth=joinpath(x.folder,string(x.ID))
-    @suppress begin
-        Pkg.activate(pth)
-        Pkg.build()
-        Pkg.activate()
-    end
+    @suppress Pkg.build()
 end
 
 """

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+AirSeaFluxes = "3dfee02d-11ce-464a-9ee1-cf3f5c5ccad7"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,9 @@
-using ClimateModels, Pkg, Documenter, Test
+using ClimateModels, Pkg, Documenter, Test, Suppressor
 
-#@testset "ClimateModels.jl" begin
-#    (mm,gm,meta)=cmip()
-#    @test isapprox(gm["y"][end],285.71875,atol=1)
-#end
+@testset "ClimateModels.jl" begin
+    (mm,gm,meta)=cmip()
+    @test isapprox(gm["y"][end],285.71875,atol=1)
+end
 
 tmp=ModelConfig()
 show(tmp)


### PR DESCRIPTION
1. fix build of doc plots in GitHub action (`GKSwstype` in `ci.yml`)
1. reactivate examples in docs (ok after fix of `ci.yml`)
1. update `build_the_pkg` (see v0.1.10)
1. add `DOCUMENTER_KEY` in `TagBot.yml`